### PR TITLE
Add Open Graph / Twitter meta tags and fix title consistency

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -6,22 +6,61 @@ import { FaLinkedin } from 'react-icons/fa';
 import styles from './Header.module.scss';
 import Button from '../Button';
 
+const SITE_URL = 'https://www.ajsevillano.com';
+const SITE_TITLE = 'Antonio Sevillano - Software Engineer';
+const SITE_DESCRIPTION =
+  'Portfolio of Antonio Sevillano, a self-taught software engineer based in the UK building web apps with React, TypeScript, Next.js and Node.js.';
+const OG_IMAGE = `${SITE_URL}/me.png`;
+
+const personJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Antonio Sevillano',
+  alternateName: 'Sevi',
+  url: SITE_URL,
+  image: OG_IMAGE,
+  jobTitle: 'Software Engineer',
+  sameAs: [
+    'https://www.linkedin.com/in/ajsevillano/',
+    'https://github.com/ajsevillano',
+    'https://bsky.app/profile/ajsevillano.bsky.social',
+  ],
+};
+
 function Header() {
   const { openDialog, closeDialog, modalRef } = useContext(ModalContext);
 
   return (
     <>
       <Head>
-        <title>Antonio Sevillano - Software developer</title>
-        <meta
-          name="description"
-          content="Antonio Sevillano - Fullstack developer"
-        />
+        <title>{SITE_TITLE}</title>
+        <meta name="description" content={SITE_DESCRIPTION} />
+        <link rel="canonical" href={`${SITE_URL}/`} />
+
+        {/* Open Graph */}
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Antonio Sevillano" />
+        <meta property="og:title" content={SITE_TITLE} />
+        <meta property="og:description" content={SITE_DESCRIPTION} />
+        <meta property="og:url" content={`${SITE_URL}/`} />
+        <meta property="og:image" content={OG_IMAGE} />
+
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={SITE_TITLE} />
+        <meta name="twitter:description" content={SITE_DESCRIPTION} />
+        <meta name="twitter:image" content={OG_IMAGE} />
+
         <meta
           name="google-site-verification"
           content="bc-C1EEIl4rOH0VMnH1Fj7p61l9sMLPXEuD0Q3bHsv0"
         />
         <link rel="icon" href="/favicon.ico" />
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
       </Head>
       <header className={styles.header}>
         <Modal closeDialog={closeDialog} ref={modalRef} />


### PR DESCRIPTION
## Summary

Adds social-sharing metadata and fixes inconsistent job titles in the document head. Improves SEO and produces proper link previews when the portfolio is shared.

Closes #28.

## Changes (`components/Header/index.tsx`)
- **Title consistency**: `<title>` is now `Antonio Sevillano - Software Engineer`, matching the page `<h1>`. The previous title ("Software developer") and meta description ("Fullstack developer") disagreed with each other and with the heading.
- **Richer meta description**, reused across the OG/Twitter tags.
- **`canonical`** link.
- **Open Graph** tags: `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image` — so LinkedIn / Bluesky / Slack render a preview card.
- **Twitter card** tags (`summary_large_image`).
- **JSON-LD `Person`** structured data with `jobTitle` and `sameAs` (LinkedIn, GitHub, Bluesky).

## Verification
- ✅ Lint clean, test suite passes (13/13).
- ✅ Rendered HTML inspected: all OG/Twitter tags and the JSON-LD block output correctly.

## Follow-up (out of scope)
- Uses `me.png` as the OG image. A dedicated 1200×630 `og-image.png` would render better in social cards.