### PR TITLE
Improve form/modal accessibility and fix empty demo anchor

### DIFF
--- a/components/Button/Button.interface.ts
+++ b/components/Button/Button.interface.ts
@@ -4,4 +4,5 @@ export interface ButtonProps {
   text: string;
   disabled?: boolean;
   onclick?: (e: any) => void;
+  type?: 'button' | 'submit' | 'reset';
 }

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -15,10 +15,12 @@ function Button({
   text = defaultProps.text,
   disabled = defaultProps.disabled,
   onclick,
+  type = 'button',
 }: ButtonProps) {
   return (
     <button
-      type="button"
+      // eslint-disable-next-line react/button-has-type
+      type={type}
       onClick={onclick}
       className={`${styles.Button} ${styles[variant as keyof typeof styles]}`}
       disabled={disabled}

--- a/components/ContactForm/index.tsx
+++ b/components/ContactForm/index.tsx
@@ -80,7 +80,7 @@ export default function ContactForm({
   };
 
   return (
-    <form className={styles.formContainer}>
+    <form className={styles.formContainer} onSubmit={sendForm}>
       {/* Honeypot: hidden from users and assistive tech, bots fill it in. */}
       <input
         ref={honeypotRef}
@@ -95,7 +95,7 @@ export default function ContactForm({
         className={styles.input}
         type="text"
         name="name"
-        id="name"
+        aria-label="Your name"
         placeholder="Your name"
         value={state.name}
         onChange={handleInputChange}
@@ -107,7 +107,7 @@ export default function ContactForm({
         className={!isValidEmail ? styles.inputError : styles.input}
         type="email"
         name="email"
-        id="email"
+        aria-label="Your email"
         placeholder="email@company.com"
         value={state.email}
         onChange={handleInputChange}
@@ -115,15 +115,15 @@ export default function ContactForm({
       <textarea
         className={styles.textArea}
         name="subject"
-        id="subject"
+        aria-label="Your message"
         placeholder="Your message"
         value={state.subject}
         onChange={handleInputChange}
       />
       <div className={styles.buttonContainer}>
         <Button
+          type="submit"
           text={buttonText}
-          onclick={(e) => sendForm(e)}
           icon={<FaPaperPlane />}
           disabled={!state.name || !state.email || !state.subject}
         />

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -26,6 +26,7 @@ const Modal = forwardRef<HTMLDialogElement, Props>(({ closeDialog }, ref) => {
     <dialog ref={ref} className={styles.modal}>
       <button
         type="button"
+        aria-label="Close contact form"
         className={styles.closeButton}
         onClick={closeDialog}
       >

--- a/components/Portfolio/Card/index.tsx
+++ b/components/Portfolio/Card/index.tsx
@@ -19,23 +19,25 @@ function Card({
   projectThumbnail,
   tags,
 }: CardDataProps) {
-  const checkDemoUrlExist = !demoURL ? null : (
-    <Button variant="secondary" text="See demo" icon={<FaLink size={20} />} />
-  );
-
   return (
     <div className={styles.card}>
       <div className={styles.imgContainer}>
         <div className={styles.hoverContainer}>
           <div className={styles.hoverContent}>
-            <a
-              data-testid="demo-link"
-              href={demoURL || ''}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {checkDemoUrlExist}
-            </a>
+            {demoURL && (
+              <a
+                data-testid="demo-link"
+                href={demoURL}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Button
+                  variant="secondary"
+                  text="See demo"
+                  icon={<FaLink size={20} />}
+                />
+              </a>
+            )}
 
             <a
               href={gitHubURL}


### PR DESCRIPTION
## Summary

Addresses two accessibility issues in the contact form / modal and removes an invalid empty anchor on project cards.

Closes #30.

## Accessibility
- **Contact form inputs** now have an `aria-label` each (`Your name` / `Your email` / `Your message`), giving them an accessible name that screen readers announce — previously they only had placeholders, which disappear on input.
- **Keyboard submit**: the form now submits via `onSubmit` with a `type="submit"` button, so pressing **Enter** submits (before, submission was wired to the button's click handler only). A `type` prop was added to the `Button` component to support this.
- **Modal close button** got an `aria-label="Close contact form"` — it was a bare "X" with no accessible name.

## Empty demo anchor
- `Card` now only renders the demo `<a>` when a `demoURL` exists. Projects without a demo previously rendered `<a href="">`, an invalid, focusable empty link.

## Note on `id` attributes
The form inputs previously carried `id="name" / "email" / "subject"`. Because the modal is rendered twice (in both `Header` and `Footer`), those ids were duplicated in the DOM — which is invalid and would break `<label htmlFor>` association. Using `aria-label` instead of `<label>` provides the accessible name without depending on unique ids, so the unused (and duplicated) ids were removed.

## Verification
- ✅ Typecheck, lint and tests (13/13) pass.
- ✅ Production build is clean.
- ✅ Rendered HTML inspected: inputs expose `aria-label`, no duplicate `id="name"`, `type="submit"` present, modal close button has its `aria-label`, and there are no empty `href=""` anchors.

## Follow-up (out of scope)
The `<Modal>` is rendered in both `Header` and `Footer` while sharing a single `modalRef` from context, producing two `<dialog>` elements (one is effectively dead markup). De-duplicating to a single modal instance would be a good structural cleanup — tracked separately.