### PR TITLE
Add security response headers via next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,31 @@
+/** @type {import('next').NextConfig} */
+
+// Applied to every route. CSP is intentionally left out for now: it needs
+// careful testing against Google Fonts, next/image inline styles and the
+// JSON-LD script before it can be enabled safely.
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains',
+  },
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Adds a `next.config.js` (the project had none) that sets security response headers on every route, improving the site's security posture and securityheaders.com score.

Closes #32.

## Headers added (applied to `/:path*`)
| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `DENY` | Clickjacking protection |
| `X-Content-Type-Options` | `nosniff` | Block MIME sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused browser features |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | Force HTTPS |

## Verification
- ✅ Clean production build.
- ✅ Verified with `curl -I` against `next start` that all five headers are present on the response.

## Out of scope / follow-up
`Content-Security-Policy` is intentionally **not** included here. A CSP must be tested against the Google Fonts `@import`, the inline styles emitted by `next/image`, and the JSON-LD `<script>` or it will break the live site — it should land in its own PR.