### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.ajsevillano.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.ajsevillano.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Adds crawler guidance and a sitemap, completing the SEO work started with the Open Graph / metadata PR.

Closes #34.

## Changes
- `public/robots.txt` — allows all crawlers and points to the sitemap.
- `public/sitemap.xml` — lists the single page (`https://www.ajsevillano.com/`).

Both are static files served directly from `/public`, using the same `www` host as the canonical and OG tags.

## Verification
- ✅ Clean production build.
- ✅ Verified with `curl` against `next start`: `/robots.txt` and `/sitemap.xml` both return `200` with the expected content.