### PR TITLE
Exclude agin-music-mobile, nextjs-auth0-prisma-starter and Image-sorter

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,9 @@
 import { FilteredProjects } from 'types/home';
 
 const FILTERED_PROJECTS: FilteredProjects[] = [
+  { id: 1248521603, name: 'agin-music-mobile' },
+  { id: 1101917853, name: 'nextjs-auth0-prisma-starter' },
+  { id: 998372342, name: 'Image-sorter' },
   { id: 378864454, name: 'izzi-howell.com' },
   { id: 642080564, name: 'pokemon.app.vanilla.js.soc' },
   { id: 518827884, name: 'reddit-clone-next12-amplify-youtube-task3' },


### PR DESCRIPTION
## Summary

Three repositories were showing on the portfolio (with the `project-progress.png` placeholder) that should not be there. This adds them to the `FILTERED_PROJECTS` exclusion array in `config.ts`.

Closes #45.

## Excluded
- `agin-music-mobile` (id 1248521603) — "Agin music mobile"
- `nextjs-auth0-prisma-starter` (id 1101917853) — "Nextjs auth0 prisma starter"
- `Image-sorter` (id 998372342) — "Image sorter"

## Verification
- ✅ Production build + rendered HTML inspected: the three projects no longer appear (0 occurrences each); the other 13 cards still render, including the unrelated `next-auth-auth0` project.
- ✅ Typecheck, lint and tests (13/13) pass.