### PR TITLE
Harden getStaticProps against GitHub API failures

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,8 +20,26 @@ import customFields from '../data';
 export const getStaticProps = async () => {
   const res = await fetch(
     'https://api.github.com/users/ajsevillano/repos?sort=created&direction=desc',
+    {
+      headers: process.env.GITHUB_TOKEN
+        ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+        : {},
+    },
   );
+
+  if (!res.ok) {
+    // eslint-disable-next-line no-console
+    console.error(`GitHub API error: ${res.status}`);
+    return { props: { projectsData: [] }, revalidate: 3600 };
+  }
+
   const data = await res.json();
+
+  if (!Array.isArray(data)) {
+    // eslint-disable-next-line no-console
+    console.error('GitHub API did not return an array');
+    return { props: { projectsData: [] }, revalidate: 3600 };
+  }
 
   const originalGithubArray: OriginalGithubArrayTypes[] = data;
   const customDataArray: CustomDataArrayTypes[] = customFields;
@@ -35,6 +53,7 @@ export const getStaticProps = async () => {
     props: {
       projectsData: processedGithubProjects,
     },
+    revalidate: 3600,
   };
 };
 


### PR DESCRIPTION
## Summary

`getStaticProps` fetched the GitHub repos list and passed the JSON straight into the array pipeline. Unauthenticated GitHub requests are rate-limited to 60 req/h per IP; when the limit is hit the API returns an object instead of an array, so `.map()` throws and the build fails:

```
TypeError: a.map is not a function
Export encountered an error on /, exiting the build.
```

Vercel build IPs are shared, so this could fail a deploy at random.

## Changes

- Bail out with an empty project list when `res.ok` is false.
- Guard with `Array.isArray(data)` before processing.
- Send an optional `Authorization: Bearer ${GITHUB_TOKEN}` header when the env var is present (raises the limit to 5,000 req/h).
- Add `revalidate: 3600` (ISR) so new repos appear without a redeploy.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- `jest` — 13/13 passing
- `next build` succeeds; route table now shows `/ → Revalidate 1h` (ISR active)

## Manual follow-up

Add a fine-grained, read-only `GITHUB_TOKEN` to the Vercel env vars to remove the rate limit at the root. The fix works without it (graceful fallback).

Closes #49