### PR TITLE
Fix solar-system thumbnail and remove dead project entries

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -20,12 +20,6 @@ const customFields: CustomDataArrayTypes[] = [
     tags: ['React Native', 'Typescript', 'Expo'],
   },
   {
-    id: 472492763,
-    demoURL: '',
-    projectThumbnail: '/project-progress.png',
-    tags: ['Typescript'],
-  },
-  {
     id: 455672935,
     demoURL: '',
     projectThumbnail: '/quiz-app.png',
@@ -36,12 +30,6 @@ const customFields: CustomDataArrayTypes[] = [
     demoURL: '',
     projectThumbnail: '/users-CRUD.png',
     tags: ['Node.js', 'Express', 'Javascript', 'PostgreSQL'],
-  },
-  {
-    id: 378864454,
-    demoURL: '',
-    projectThumbnail: '/project-progress.png',
-    tags: ['Typescript'],
   },
   {
     id: 362217174,
@@ -106,7 +94,7 @@ const customFields: CustomDataArrayTypes[] = [
   {
     id: 296066823,
     demoURL: null,
-    projectThumbnail: '/project-progress.png',
+    projectThumbnail: '/solar-system.png',
     tags: ['React', 'Sass'],
   },
   {


### PR DESCRIPTION
## Summary

Three `data.ts` entries pointed at the `/project-progress.png` placeholder, but only one was ever rendered.

| id | repo | status |
|----|------|--------|
| `296066823` | solar-system | **rendered** — `/solar-system.png` already in `/public` |
| `472492763` | *(404 / deleted)* | dead entry, never matches a live repo |
| `378864454` | izzihowell.com | excluded via `FILTERED_PROJECTS`, never rendered |

## Changes

- Point `296066823` at `/solar-system.png` (removes the only visible placeholder).
- Remove the two dead entries (`472492763`, `378864454`) from `data.ts`.

`FILTERED_PROJECTS` is left untouched: it filters the live `izzihowell.com` repo out of the API results, independently of the removed metadata entry. `project-progress.png` is kept as the fallback for repos without custom metadata (`Card/index.tsx`).

## Verification

- `tsc --noEmit` clean, `jest` 13/13, `next build` succeeds.

Closes #50