### PR TITLE
De-duplicate the contact Modal

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { FaRegClipboard } from 'react-icons/fa';
-import Modal from '@components/Modal';
 import { ModalContext } from '../../contexts/ModalContext';
 import Button from '../Button';
 import Wrapper from '../Layouts/Wrapper';
@@ -8,7 +7,7 @@ import styles from './Footer.module.scss';
 import contactLinks from './Footer.data';
 
 function Footer() {
-  const { openDialog, closeDialog, modalRef } = useContext(ModalContext);
+  const { openDialog } = useContext(ModalContext);
   return (
     <Wrapper
       elementType="section"
@@ -17,7 +16,6 @@ function Footer() {
       justifycontent="center"
     >
       <div className={styles.sectionContainer}>
-        <Modal closeDialog={closeDialog} ref={modalRef} />
         <div className={styles.contactMeHeader}>
           <h2 className={styles.contactMe}>Contact me</h2>
           <p className={styles.subTitle}>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import Head from 'next/head';
-import Modal from '@components/Modal';
 import { ModalContext } from 'contexts/ModalContext';
 import { FaLinkedin } from 'react-icons/fa';
 import styles from './Header.module.scss';
@@ -29,7 +28,7 @@ const personJsonLd = {
 };
 
 function Header() {
-  const { openDialog, closeDialog, modalRef } = useContext(ModalContext);
+  const { openDialog } = useContext(ModalContext);
 
   return (
     <>
@@ -66,7 +65,6 @@ function Header() {
         />
       </Head>
       <header className={styles.header}>
-        <Modal closeDialog={closeDialog} ref={modalRef} />
         <div className={styles.container}>
           <div className={styles.imgContainer}>
             <img className={styles.image} src="./profile.png" alt="Me" />

--- a/contexts/ModalContext.tsx
+++ b/contexts/ModalContext.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react';
+import Modal from '@components/Modal';
 
 interface ModalContextProps {
   openDialog: () => void;
@@ -46,6 +47,9 @@ export function ModalProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <ModalContext.Provider value={value}>{children}</ModalContext.Provider>
+    <ModalContext.Provider value={value}>
+      {children}
+      <Modal closeDialog={closeDialog} ref={modalRef} />
+    </ModalContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary

The `<Modal>` was rendered in **both** `Header` and `Footer`, each binding the single shared `modalRef` from `ModalContext`. Because a React ref can only attach to one element, it bound to whichever mounted last (`Footer`), leaving the `Header`'s `<dialog>` as **dead markup**. Side effects:

- Two `<dialog>` elements in the DOM.
- Two `ContactForm` instances (duplicate ids — the reason inputs use `aria-label` instead of `<label htmlFor>`).
- Two `Escape` key listeners.

## Changes

- Render the `<Modal>` **once** inside `ModalProvider`, which already owns `modalRef` and `closeDialog`.
- `Header` and `Footer` no longer render their own `Modal`; they only consume `openDialog`.

## Verification

- `tsc --noEmit` clean, `eslint` clean (no orphaned vars, no circular import), `jest` 13/13, `next build` succeeds.
- Rendered HTML now contains exactly **one** `<dialog>` (was two).

## Follow-up (not in this PR)

With a single `ContactForm` instance the duplicate-id problem is gone, so inputs could be migrated back to proper `<label htmlFor>` for a small accessibility win.

Closes #41