### PR TITLE
Improve contact form accessibility with visible labels

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "react/require-default-props": [0],
     "object-curly-newline": [0],
     "implicit-arrow-linebreak": [0],
-    "operator-linebreak": "off"
+    "operator-linebreak": "off",
+    "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }]
   }
 }

--- a/components/ContactForm/ContactForm.module.scss
+++ b/components/ContactForm/ContactForm.module.scss
@@ -5,6 +5,13 @@
   width: 90%;
   margin: 1rem 0 0;
 
+  .label {
+    font-size: 0.85rem;
+    color: #30363a;
+    font-weight: 500;
+    margin-bottom: 0.4rem;
+  }
+
   .input {
     width: 100%;
     height: 2.5rem;

--- a/components/ContactForm/index.tsx
+++ b/components/ContactForm/index.tsx
@@ -92,31 +92,42 @@ export default function ContactForm({
         aria-hidden="true"
         style={{ display: 'none' }}
       />
+      <label className={styles.label} htmlFor="name">
+        Your name
+      </label>
       <input
         className={styles.input}
+        id="name"
         type="text"
         name="name"
-        aria-label="Your name"
         placeholder="Your name"
         value={state.name}
         onChange={handleInputChange}
       />
-      <span className={styles.errorText}>
-        {!isValidEmail ? 'Please enter a valid email' : ''}
-      </span>
+      <label className={styles.label} htmlFor="email">
+        Your email
+      </label>
       <input
         className={!isValidEmail ? styles.inputError : styles.input}
+        id="email"
         type="email"
         name="email"
-        aria-label="Your email"
         placeholder="email@company.com"
         value={state.email}
         onChange={handleInputChange}
+        aria-invalid={!isValidEmail}
+        aria-describedby="email-error"
       />
+      <span className={styles.errorText} id="email-error" role="alert">
+        {!isValidEmail ? 'Please enter a valid email' : ''}
+      </span>
+      <label className={styles.label} htmlFor="message">
+        Your message
+      </label>
       <textarea
         className={styles.textArea}
+        id="message"
         name="subject"
-        aria-label="Your message"
         placeholder="Your message"
         value={state.subject}
         onChange={handleInputChange}


### PR DESCRIPTION
## Summary

The contact form used `placeholder` text as the only visible label (a WCAG anti-pattern — placeholders disappear on input and have low contrast) with `aria-label` for assistive tech. The email validation error was also not programmatically tied to the field.

## Changes

- Add visible `<label htmlFor>` for name, email and message, each matched by an `id` on the control.
- Associate the email validation error with the field: `aria-invalid`, `aria-describedby`, and `role="alert"` so screen readers announce it.
- Relax `jsx-a11y/label-has-associated-control` to `assert: 'either'` so `htmlFor`/`id` association (valid per W3C) is accepted without forcing the input to be nested inside the label.

This is possible now that the Modal renders once (#41), so field ids are unique across the page.

## Verification

- `tsc --noEmit` clean, `eslint` clean, `jest` 13/13, `next build` succeeds.
- Rendered HTML shows `<label for="name|email|message">` plus `aria-describedby` / `id="email-error"` / `role="alert"`.

Closes #58